### PR TITLE
Increase Compat for PromptingTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.3.0]
+
+### Added
+- Changed compat for PromptingTools to 0.10.0 (with new default models! Ie, default embeddings will not match the previous version)
+
 ## [0.2.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LLMTextAnalysis"
 uuid = "a88142f3-a164-49e9-925a-9408902b6922"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
@@ -41,7 +41,7 @@ MLJLinearModels = "0.10"
 PlotlyJS = "0.18"
 Plots = "1"
 PrecompileTools = "1"
-PromptingTools = "0.7"
+PromptingTools = "0.10"
 Snowball = "0.1.1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"


### PR DESCRIPTION
- Changed compat for PromptingTools to 0.10.0 (with new default models! Ie, default embeddings will not match the previous version)
