### PR TITLE
Customize Topic Labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.0]
+
+### Added
+- Added a new example on topic label customization (`examples/3_customize_topic_labels.jl`) and the corresponding sections in the FAQ.
+- Added a few string cleanup tricks in `build_topic` function to strip unnecessary repetition of the prompt template in the generated labels.
+- Added new templates `TopicLabelerWithInstructions` and `TopicSummarizerWithInstructions` that include the placeholder `instructions` to allow users to easily customize the labels and summaries, respectively.
+
+### Fixed
+- Fixed small typos in templates `TopicLabelerBasic` and `TopicSummarizerBasic`.
+
+## Updated
+- Updated logic in the `plot` to ensure topic labels are generated only when necessary. Use `build_clusters!` to force the generation of topic labels, or `plot` to generate them only if necessary.
+- Increased compatibility for PromptingTools to 0.12.
+
 ## [0.3.2]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LLMTextAnalysis"
 uuid = "a88142f3-a164-49e9-925a-9408902b6922"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
@@ -39,9 +39,9 @@ LinearAlgebra = "<0.0.1, 1"
 Logging = "<0.0.1, 1"
 MLJLinearModels = "0.10"
 PlotlyJS = "0.18"
-Plots = "1"
+Plots = "1.35 - 1.40"
 PrecompileTools = "1"
-PromptingTools = "0.10"
+PromptingTools = "0.12"
 Snowball = "0.1.1"
 SparseArrays = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"

--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -31,8 +31,7 @@ using Serialization
 
 # Leverage serialization to save time in the future
 if !isfile("my_index.jls")
-    index = build_index(docs;
-        labeler_kwargs = (; model = "gpt3t"))
+    index = build_index(docs);
     build_clusters!(index; k = 20, labeler_kwargs = (; model = "gpt3t"))
     ## Skip UMAP as it's too slow, do a simple PCA-like approximation
     ## we should center the data first, often it is scaled as well but with normalized embeddings it should be okay
@@ -49,7 +48,7 @@ end
 
 In general, we overload `Plots.plot()` and `PlotlyJS.plot()` for plotting. You need to import only one of them.
 
-If you call `plotlyjs()` as well, the `Plots.plot()` will be interactive with PlotlyJS backend.
+If you call `plotlyjs()` as well, the `Plots.plot()` will be interactive with the PlotlyJS backend. Using `plotlyjs()` requires having `PlotlyJS` added to your project (not imported, but added)!
 
 In the documentation, we need to use `using PlotlyJS, PlotlyDocumenter`, but that's only for the docsite (see `examples/1_topics_in_city_of_austin_community_survey.jl`).
 
@@ -88,6 +87,158 @@ pl = plot(index;
 ```
 
 Explore adding more `hoverdata` to each point in the scatter, in my experience, it makes the plot more informative (see `?plot` for more details).
+
+## How to customize the topic labels?
+
+The topic labels are generated via a "template" (keyword argument `label_template` for the labeling function). 
+
+We default to "TopicLabelerBasic" (saved in `templates/topic-metadata/TopicLabelerBasic.jl`), but you can change the template and pass it to `build_clusters!()` or `plot()` via the `labeler_kwargs` keyword argument (eg, `labeler_kwargs = (; label_template=:MyTopicLabels)`).
+
+Why use the templates? We need to guarantee that you provide placeholders for `central_text`, `samples` and `keywords` in your template for everything to work, so we cannot simply accept any user-provided string. 
+
+Depending on how radically different your labels need to be, you have two choices: 
+
+1) for smaller changes, use `instructions` placeholder in the `TopicLabelerWithInstructions` template. You should always start with this one.
+2) for larger changes, you can create a new template, save it, load it to your template store and pass it to `labeler_kwargs` as mentioned above.
+
+Our setup - let's say we need our labels to be in French because our documents are.
+
+```julia
+using PromptingTools
+const PT = PromptingTools
+
+## Note: I don't speak French, so apologies for any mistakes or NSFW content below
+french_sentences = [
+    "Bonjour, comment ça va?",
+    "Je m'appelle Marie.",
+    "Il fait beau aujourd'hui.",
+    "Quel est ton plat préféré?",
+    "J'adore voyager dans le monde.",
+    "As-tu vu ce film?",
+    "A quelle heure est le rendez-vous?",
+    "Les chats sont mignons.",
+    "Tu veux sortir ce soir?",
+    "C'est délicieux!",
+    "Où se trouve la bibliothèque?",
+    "Tu parles plusieurs langues?",
+    "J'aime écouter de la musique.",
+    "Quel est ton sport préféré?",
+    "Il est tard, tu devrais dormir.",
+    "Quel temps fait-il demain?",
+    "Je suis très fatigué.",
+    "C'est une bonne idée.",
+    "Tu me manques.",
+    "Il faut rester positif."
+]
+
+## Index as usual
+index = build_index(french_sentences)
+```
+
+### Example of using `TopicLabelerWithInstructions`
+
+We need to change the label template to `TopicLabelerWithInstructions` and provide the instructions in the `labeler_kwargs` argument.
+
+```julia
+build_clusters!(
+    index; k = 3,
+    labeler_kwargs = (; label_template = :TopicLabelerWithInstructions,
+        instructions = "All topic names must be translated to French.", model = "gpt3t"))
+
+## Let's check the labels (3 refers to the number of clusters)
+k=3
+index.topic_levels[k]
+## 3-element Vector{TopicMetadata}:
+##  TopicMetadata(ID: 1/3, Documents: 1, Label: "Étude du Comportement du Renard et du Chien",  Summary: -)
+##  TopicMetadata(ID: 2/3, Documents: 3, Label: "Économie Financière Comportementale",  Summary: -)
+##  TopicMetadata(ID: 3/3, Documents: 16, Label: "Les Proverbes de la Vie",  Summary: -)
+
+# Note: I don't speak French, so I'm not sure if the labels are correct. It might take some tweaking of the instructions to get the labels right.
+
+# If needed, you can always tweak the labels manually
+index.topic_levels[k][1].label = "Étude du Comportement du Renard et du Chien - 123456789"
+```
+
+How would we find available templates? `aitemplates("Labeler")`!
+
+We would see the templates with partial match, what they do and the PLACEHOLDERS they require, eg, 
+```plaintext
+PromptingTools.AITemplateMetadata
+  name: Symbol TopicLabelerWithInstructions
+  description: String "Advanced labeler for a given topic/theme in 2-5 words based on the provided central text, samples and keywords. It provides a field for special instructions. If you do not have any special instructions, provide `instructions=\"None.\"`. Placeholders: `central_text`, `samples`, `keywords`, `instructions`"
+  version: String "1.0"
+  wordcount: Int64 653
+  variables: Array{Symbol}((4,))
+  system_preview: String "Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.\n"
+  user_preview: String "###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}"
+  source: String ""
+```
+
+### Example of creating a new template
+
+We first duplicate the `TopicLabelerBasic` template to have a starting point and 2 add two new instructions in section "Topic Name Instructions".
+
+```julia
+tpl_custom = [
+    PT.SystemMessage("""
+Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.
+
+Your task is create a topic name based on the provided information and sample texts.
+
+**Topic Name Instructions:**
+- A short phrase, ideally 2-5 words.
+- Descriptive of the information provided.
+- Brief and concise.
+- Title Cased.
+- Must be in French.
+- Must be a question.
+"""),
+    PT.UserMessage("""
+    ###Central Text###
+    {{central_text}}
+
+    ###Sample Texts###
+    {{samples}}
+
+    ###Common Words###
+    {{keywords}}
+
+    The most suitable topic name is:",
+    """)]
+filename = joinpath("templates",
+    "topic-metadata",
+    "MyTopicLabels.json")
+PT.save_template(filename,
+    tpl_custom;
+    version = "1.0",
+    description = "My custom template for topic labeling. Placeholders: `central_text`, `samples`, `keywords`")
+```
+Note: The filename of the template is "MyTopicLabels.json", so the template will be accessible in the code as `:MyTopicLabels` (symbols signify the use of templates).
+
+We need to explicitly re-load all templates with `load_templates!()` to make the new template available for use.
+
+```julia
+load_templates!()
+```
+
+Then to force overwrite the existing labels with the new template, we call `build_clusters!` with the `labeler_kwargs` argument.
+
+```julia
+# Notice that we provide the label_template argument that matches the file name of the template we created
+build_clusters!(
+    index; k = 3, labeler_kwargs = (; label_template = :MyTopicLabels, model = "gpt3t"))
+pl = plot(index; k = 3,
+    title = "Sujets d'actualité du 2024-02-13")
+```
+
+### Difference between labeler_kwargs for `build_clusters!` and `plot`
+
+So when should I use `build_clusters!` and when should I simply use `plot`?
+
+It depends if you want to overwrite any existing topic labels with the provided `labeler_kwargs` or not:
+
+- `plot` call will only create new labels if you specify `k` (number of clusters) that **is NOT available yet** (ie, no key available in `index.topic_levels`).
+- `build_clusters!` will always overwrite the existing labels if you specify `k` (number of clusters).
 
 ## What's next for this package?
 

--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -161,7 +161,7 @@ index.topic_levels[k][1].label = "Étude du Comportement du Renard et du Chien -
 
 How would we find available templates? `aitemplates("Labeler")`!
 
-We would see the templates with partial match, what they do and the PLACEHOLDERS they require, eg, 
+We would see the templates with a partial match, what they do and the PLACEHOLDERS they require, eg, 
 ```plaintext
 PromptingTools.AITemplateMetadata
   name: Symbol TopicLabelerWithInstructions
@@ -176,7 +176,7 @@ PromptingTools.AITemplateMetadata
 
 ### Example of creating a new template
 
-We first duplicate the `TopicLabelerBasic` template to have a starting point and 2 add two new instructions in section "Topic Name Instructions".
+We first duplicate the `TopicLabelerBasic` template to have a starting point and add two new instructions in the section "Topic Name Instructions".
 
 ```julia
 tpl_custom = [

--- a/examples/3_customize_topic_labels.jl
+++ b/examples/3_customize_topic_labels.jl
@@ -1,0 +1,153 @@
+# # Example 3: Customize Topic Labels
+# The focus of this tutorial is how to customize the topic labels in the plot.
+# 
+# For this tutorial, we will use the [City of Austin's Community Survey](https://data.austintexas.gov/Health-and-Community-Services/2019-City-of-Austin-Community-Survey/s2py-ceb7).
+# We will pick one open-ended question and extract the main themes from the answers.
+
+# Necessary imports
+using Downloads, CSV, DataFrames
+using Plots
+using LLMTextAnalysis
+##PLOTLYJS##
+plotlyjs(); # recommended backend for interactivity, install with `using Pkg; Pkg.add("PlotlyJS")`
+
+# ## Customizing Topic Labels
+
+# The topic labels are generated via a "template" (keyword argument `label_template` for the labeling function). 
+#
+# We default to "TopicLabelerBasic" (saved in `templates/topic-metadata/TopicLabelerBasic.jl`), but you can change the template and pass it to `build_clusters!()` or `plot()` via the `labeler_kwargs` keyword argument (eg, `labeler_kwargs = (; label_template=:MyTopicLabels)`).
+#
+# Why use the templates? We need to guarantee that you provide placeholders for `central_text`, `samples` and `keywords` in your template for everything to work, so we cannot simply accept any user-provided string. 
+#
+# Depending on how radically different your labels need to be, you have two choices: 
+#
+# 1) for smaller changes, use `instructions` placeholder in the `TopicLabelerWithInstructions` template. You should always start with this one.
+# 2) for larger changes, you can create a new template, save it, load it to your template store and pass it to `labeler_kwargs` as mentioned above.
+
+# ## Prepare the data and index
+
+# Our setup - let's say we need our labels to be in French because our documents are.
+#
+# Note: I don't speak French, so apologies for any mistakes or NSFW content below
+french_sentences = [
+    "Bonjour, comment ça va?",
+    "Je m'appelle Marie.",
+    "Il fait beau aujourd'hui.",
+    "Quel est ton plat préféré?",
+    "J'adore voyager dans le monde.",
+    "As-tu vu ce film?",
+    "A quelle heure est le rendez-vous?",
+    "Les chats sont mignons.",
+    "Tu veux sortir ce soir?",
+    "C'est délicieux!",
+    "Où se trouve la bibliothèque?",
+    "Tu parles plusieurs langues?",
+    "J'aime écouter de la musique.",
+    "Quel est ton sport préféré?",
+    "Il est tard, tu devrais dormir.",
+    "Quel temps fait-il demain?",
+    "Je suis très fatigué.",
+    "C'est une bonne idée.",
+    "Tu me manques.",
+    "Il faut rester positif."
+]
+
+# Index as usual
+index = build_index(french_sentences)
+
+# ## Example of using `TopicLabelerWithInstructions`
+
+# We need to change the label template to `TopicLabelerWithInstructions` and provide the instructions in the `labeler_kwargs` argument.
+
+build_clusters!(
+    index; k = 3,
+    labeler_kwargs = (; label_template = :TopicLabelerWithInstructions,
+        instructions = "All topic names must be translated to French.", model = "gpt3t"))
+
+# Let's check the labels (3 refers to the number of clusters)
+k = 3
+index.topic_levels[k]
+## 3-element Vector{TopicMetadata}:
+##  TopicMetadata(ID: 1/3, Documents: 1, Label: "Étude du Comportement du Renard et du Chien",  Summary: -)
+##  TopicMetadata(ID: 2/3, Documents: 3, Label: "Économie Financière Comportementale",  Summary: -)
+##  TopicMetadata(ID: 3/3, Documents: 16, Label: "Les Proverbes de la Vie",  Summary: -)
+
+# Note: I don't speak French, so I'm not sure if the labels are correct. It might take some tweaking of the instructions to get the labels right.
+
+# If needed, you can always tweak the labels manually
+index.topic_levels[k][1].label = "Étude du Comportement du Renard et du Chien - 123456789"
+
+# How would we find available templates? `aitemplates("Labeler")`!
+
+# We would see the templates with partial match, what they do and the PLACEHOLDERS they require, eg, 
+#
+## PromptingTools.AITemplateMetadata
+##   name: Symbol TopicLabelerWithInstructions
+##   description: String "Advanced labeler for a given topic/theme in 2-5 words based on the provided central text, samples and keywords. It provides a field for special instructions. If you do not have any special instructions, provide `instructions=\"None.\"`. Placeholders: `central_text`, `samples`, `keywords`, `instructions`"
+##   version: String "1.0"
+##   wordcount: Int64 653
+##   variables: Array{Symbol}((4,))
+##   system_preview: String "Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.\n"
+##   user_preview: String "###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}"
+##   source: String ""
+
+# ## Example of creating a new template
+
+# We first duplicate the `TopicLabelerBasic` template to have a starting point and 2 add two new instructions in section "Topic Name Instructions".
+
+tpl_custom = [
+    PT.SystemMessage("""
+Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.
+
+Your task is create a topic name based on the provided information and sample texts.
+
+**Topic Name Instructions:**
+- A short phrase, ideally 2-5 words.
+- Descriptive of the information provided.
+- Brief and concise.
+- Title Cased.
+- Must be in French.
+- Must be a question.
+"""),
+    PT.UserMessage("""
+    ###Central Text###
+    {{central_text}}
+
+    ###Sample Texts###
+    {{samples}}
+
+    ###Common Words###
+    {{keywords}}
+
+    The most suitable topic name is:",
+    """)]
+filename = joinpath("templates",
+    "topic-metadata",
+    "MyTopicLabels.json")
+PT.save_template(filename,
+    tpl_custom;
+    version = "1.0",
+    description = "My custom template for topic labeling. Placeholders: `central_text`, `samples`, `keywords`")
+
+# Note: The filename of the template is "MyTopicLabels.json", so the template will be accessible in the code as `:MyTopicLabels` (symbols signify the use of templates).
+#
+# We need to explicitly re-load all templates with `load_templates!()` to make the new template available for use.
+
+load_templates!()
+
+# Then to force overwrite the existing labels with the new template, we call `build_clusters!` with the `labeler_kwargs` argument.
+#
+# Notice that we provide the label_template argument that matches the file name of the template we created
+build_clusters!(
+    index; k = 3, labeler_kwargs = (; label_template = :MyTopicLabels, model = "gpt3t"))
+pl = plot(index; k = 3,
+    title = "Sujets d'actualité du 2024-02-13")
+
+# ## Difference between labeler_kwargs for `build_clusters!` and `plot`
+
+# So when should I use `build_clusters!` and when should I simply use `plot`?
+#
+# It depends if you want to overwrite any existing topic labels with the provided `labeler_kwargs` or not:
+#
+# - `plot` call will only create new labels if you specify `k` (number of clusters) that **is NOT available yet** (ie, no key available in `index.topic_levels`).
+# - `build_clusters!` will always overwrite the existing labels if you specify `k` (number of clusters).

--- a/ext/PlotlyJSLLMTextAnalysisExt.jl
+++ b/ext/PlotlyJSLLMTextAnalysisExt.jl
@@ -45,7 +45,10 @@ function PlotlyJS.plot(index::AbstractDocumentIndex; verbose::Bool = true,
     prepare_plot!(index; verbose)
     ## Prepare a clustering
     previous_topic_levels = keys(index.topic_levels)
-    build_clusters!(index; verbose, k, h, labeler_kwargs, cluster_kwargs...)
+    ## do we need to build clusters for this k?
+    if (isnothing(k) && isnothing(h)) || (!isnothing(k) && !haskey(index.topic_levels, k))
+        build_clusters!(index; verbose, k, h, labeler_kwargs, cluster_kwargs...)
+    end
     ## Pick topic_level if not provided
     topic_level = if !isnothing(k)
         k
@@ -76,8 +79,10 @@ function PlotlyJS.plot(index::AbstractDocumentIndex; verbose::Bool = true,
                 hovertemplate = "<b>Topic:</b> $(topic.label)<br><b>Text:</b> %{text}<br>%{customdata}<extra></extra>"
                 subset = Tables.subset(hoverdata, docs_idx; viewhint = true)
                 customdata = map(Tables.rows(subset)) do row
-                    join(["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
-                          for col in Tables.columnnames(row)], "<br>")
+                    join(
+                        ["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
+                         for col in Tables.columnnames(row)],
+                        "<br>")
                 end
             end
         else
@@ -162,8 +167,10 @@ function PlotlyJS.plot(index::AbstractDocumentIndex,
         else
             hovertemplate = "<b>Text:</b> %{text}<br><b>Score #1</b>: %{x}<br><b>Score #2</b>: %{y:,.0%}<br>%{customdata}<extra></extra>"
             customdata = map(Tables.rows(hoverdata)) do row
-                join(["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
-                      for col in Tables.columnnames(row)], "<br>")
+                join(
+                    ["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
+                     for col in Tables.columnnames(row)],
+                    "<br>")
             end
         end
     else

--- a/ext/PlotsLLMTextAnalysisExt.jl
+++ b/ext/PlotsLLMTextAnalysisExt.jl
@@ -45,7 +45,10 @@ function Plots.plot(index::AbstractDocumentIndex; verbose::Bool = true,
     prepare_plot!(index; verbose)
     ## Prepare a clustering
     previous_topic_levels = keys(index.topic_levels)
-    build_clusters!(index; verbose, k, h, labeler_kwargs, cluster_kwargs...)
+    ## do we need to build clusters for this k?
+    if (isnothing(k) && isnothing(h)) || (!isnothing(k) && !haskey(index.topic_levels, k))
+        build_clusters!(index; verbose, k, h, labeler_kwargs, cluster_kwargs...)
+    end
     ## Pick topic_level if not provided
     topic_level = if !isnothing(k)
         k
@@ -76,8 +79,10 @@ function Plots.plot(index::AbstractDocumentIndex; verbose::Bool = true,
             else
                 subset = Tables.subset(hoverdata, docs_idx; viewhint = true)
                 map(Tables.rows(subset)) do row
-                    join(["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
-                          for col in Tables.columnnames(row)], "<br>")
+                    join(
+                        ["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
+                         for col in Tables.columnnames(row)],
+                        "<br>")
                 end
             end
             ["""
@@ -153,8 +158,10 @@ function Plots.plot(index::AbstractDocumentIndex,
             fill("", length(scores1))
         else
             map(Tables.rows(hoverdata)) do row
-                join(["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
-                      for col in Tables.columnnames(row)], "<br>")
+                join(
+                    ["<b>$(col)</b>: $(Tables.getcolumn(row,col))"
+                     for col in Tables.columnnames(row)],
+                    "<br>")
             end
         end
         ["""

--- a/src/LLMTextAnalysis.jl
+++ b/src/LLMTextAnalysis.jl
@@ -10,6 +10,7 @@ using Statistics: mean
 using MLJLinearModels, Tables
 const PT = PromptingTools
 
+export load_templates!
 # export nunique, sigmoid
 include("utils.jl")
 
@@ -30,8 +31,7 @@ include("concept_labeling.jl")
 
 function __init__()
     ## Load extra templates
-    PT.load_templates!() # refresh base templates
-    PT.load_templates!(joinpath(@__DIR__, "..", "templates"); remove_templates = false) # add our custom ones
+    load_templates!()
 end
 
 # TODO: Enable precompilation to reduce start time, disabled logging

--- a/src/topic_modelling.jl
+++ b/src/topic_modelling.jl
@@ -36,7 +36,8 @@ assignments = [1, 1]
 metadata = build_topic(index, assignments, 1)
 ```
 """
-function build_topic(index::AbstractDocumentIndex, assignments::Vector{Int}, topic_idx::Int;
+function build_topic(
+        index::AbstractDocumentIndex, assignments::Vector{Int}, topic_idx::Int;
         topic_level::Int = nunique(assignments),
         verbose::Bool = false, add_label::Bool = true, add_summary::Bool = false,
         label_template::Union{Nothing, Symbol} = :TopicLabelerBasic,
@@ -97,7 +98,10 @@ function build_topic(index::AbstractDocumentIndex, assignments::Vector{Int}, top
             aikwargs...)
         !isnothing(cost_tracker) &&
             Threads.atomic_add!(cost_tracker, PT.call_cost(msg, model)) # track costs
-        msg.content
+        ## quick hack for weaker models that repeat the sentence
+        clean = split(msg.content, "###\n")[end]
+        clean = split(clean, "topic name is:")[end]
+        strip(clean)
     else
         ""
     end
@@ -111,7 +115,9 @@ function build_topic(index::AbstractDocumentIndex, assignments::Vector{Int}, top
             aikwargs...)
         !isnothing(cost_tracker) &&
             Threads.atomic_add!(cost_tracker, PT.call_cost(msg, model)) # track costs
-        msg.content
+        ## quick hack for weaker models that repeat the sentence
+        clean = split(msg.content, "###\n")[end]
+        strip(clean)
     else
         ""
     end
@@ -181,7 +187,8 @@ function build_clusters!(index::AbstractDocumentIndex; k::Union{Int, Nothing} = 
         verbose && @info "Cutting clusters at k=$k..."
         assignments = cutree(index.clustering; k)
         count_topics = nunique(assignments)
-        topics = asyncmap(i -> build_topic(index,
+        topics = asyncmap(
+            i -> build_topic(index,
                 assignments,
                 i;
                 topic_kwargs...,
@@ -198,7 +205,8 @@ function build_clusters!(index::AbstractDocumentIndex; k::Union{Int, Nothing} = 
         count_topics = nunique(assignments)
         ## early exit to not duplicate work
         count_topics == remember_count_clusters && return index
-        topics = asyncmap(i -> build_topic(index,
+        topics = asyncmap(
+            i -> build_topic(index,
                 assignments,
                 i;
                 topic_kwargs...,
@@ -213,7 +221,8 @@ function build_clusters!(index::AbstractDocumentIndex; k::Union{Int, Nothing} = 
         verbose && @info "Cutting clusters at k=$k..."
         assignments = cutree(index.clustering; k)
         count_topics = nunique(assignments)
-        topics = asyncmap(i -> build_topic(index,
+        topics = asyncmap(
+            i -> build_topic(index,
                 assignments,
                 i;
                 topic_kwargs...,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,14 @@
+"""
+    load_templates!()
+
+Reloads the templates from PromptingTools.jl and the custom ones in LLMTextAnalysis.jl (saved in `templates/` folders).
+"""
+function load_templates!()
+    ## Load extra templates
+    PT.load_templates!() # refresh base templates
+    PT.load_templates!(joinpath(@__DIR__, "..", "templates"); remove_templates = false) # add our custom ones
+end
+
 "Counts number of unique elements in a vector"
 nunique(vect::AbstractVector) = length(unique(vect))
 sigmoid(x::Real) = 1.0 / (1.0 + exp(-x))

--- a/templates/topic-metadata/TopicLabelerBasic.json
+++ b/templates/topic-metadata/TopicLabelerBasic.json
@@ -2,12 +2,12 @@
     {
         "content": "Template Metadata",
         "description": "Labels a given topic/theme in 2-5 words based on the provided central text, samples and keywords. Placeholders: `central_text`, `samples`, `keywords`",
-        "version": "1.0",
+        "version": "1.1",
         "source": "",
         "_type": "metadatamessage"
     },
     {
-        "content": "Act a world-class behavioural researcher, unbiased and trained to surface key underlying themes.\n\nYour task is create a topic name based on the provided information and sample texts.\n\n**Topic Name Instructions:**\n- A short phrase, ideally 2-5 words.\n- Descriptive of the information provided.\n- Brief and concise.\n- Title Cased.\n\n",
+        "content": "Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.\n\nYour task is create a topic name based on the provided information and sample texts.\n\n**Topic Name Instructions:**\n- A short phrase, ideally 2-5 words.\n- Descriptive of the information provided.\n- Brief and concise.\n- Title Cased.\n\n",
         "variables": [],
         "_type": "systemmessage"
     },

--- a/templates/topic-metadata/TopicLabelerWithInstructions.json
+++ b/templates/topic-metadata/TopicLabelerWithInstructions.json
@@ -1,0 +1,24 @@
+[
+    {
+        "content": "Template Metadata",
+        "description": "Advanced labeler for a given topic/theme in 2-5 words based on the provided central text, samples and keywords. It provides a field for special instructions. If you do not have any special instructions, provide `instructions=\"None.\"`. Placeholders: `central_text`, `samples`, `keywords`, `instructions`",
+        "version": "1.0",
+        "source": "",
+        "_type": "metadatamessage"
+    },
+    {
+        "content": "Act as a world-class behavioural researcher, unbiased and trained to surface key underlying themes.\n\nYour task is create a topic name based on the provided information and sample texts.\n\n**Topic Name Instructions:**\n- A short phrase, ideally 2-5 words.\n- Descriptive of the information provided.\n- Brief and concise.\n- Title Cased.\n\nIf Special Instructions are provided by the user, they take precedence over any previous instructions. You MUST follow the instructions precisely.\n",
+        "variables": [],
+        "_type": "systemmessage"
+    },
+    {
+        "content": "###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}\n\n###Special Instructions###\n{{instructions}}\n\nThe most suitable topic name is:\",\n",
+        "variables": [
+            "central_text",
+            "samples",
+            "keywords",
+            "instructions"
+        ],
+        "_type": "usermessage"
+    }
+]

--- a/templates/topic-metadata/TopicSummarizerBasic.json
+++ b/templates/topic-metadata/TopicSummarizerBasic.json
@@ -2,17 +2,17 @@
     {
         "content": "Template Metadata",
         "description": "Summarizes a given topic/theme in 2-3 bullet points based on the provided central text, samples and keywords. Placeholders: `central_text`, `samples`, `keywords`",
-        "version": "1.0",
+        "version": "1.1",
         "source": "",
         "_type": "metadatamessage"
     },
     {
-        "content": "Act a world-class journalist, unbiased and trained to surface key underlying themes.\n\nYour task is provide a brief and punchy summary of the underlying themes and topics based on the provided information and sample texts.\n\n**Summary Instructions:**\n- Use bullet points.\n- Write 2-3 sentences to summarise the underlying themes and topics.\n- Using ONLY the information provided, do not add any additional information that is not provided.\n- Be brief and concise.\n\n###Summary###\n",
+        "content": "Act a world-class journalist, unbiased and trained to surface key underlying themes.\n\nYour task is provide a brief and punchy summary of the underlying themes and topics based on the provided information and sample texts.\n\n**Summary Instructions:**\n- Use bullet points.\n- Write 2-3 sentences to summarise the underlying themes and topics.\n- Using ONLY the information provided, do not add any additional information that is not provided.\n- Be brief and concise.",
         "variables": [],
         "_type": "systemmessage"
     },
     {
-        "content": "\n###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}\n\nTopic Name:\n    ",
+        "content": "\n###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}\n\n###Summary###\n",
         "variables": [
             "central_text",
             "samples",

--- a/templates/topic-metadata/TopicSummarizerWithInstructions.json
+++ b/templates/topic-metadata/TopicSummarizerWithInstructions.json
@@ -1,0 +1,23 @@
+[
+    {
+        "content": "Template Metadata",
+        "description": "Advanced summarizer for a given topic/theme in 2-3 bullet points based on the provided central text, samples and keywords. It provides a field for special instructions. If you do not have any special instructions, provide `instructions=\"None.\"`. Placeholders: `central_text`, `samples`, `keywords`, `instructions`",
+        "version": "1.1",
+        "source": "",
+        "_type": "metadatamessage"
+    },
+    {
+        "content": "Act a world-class journalist, unbiased and trained to surface key underlying themes.\n\nYour task is provide a brief and punchy summary of the underlying themes and topics based on the provided information and sample texts.\n\n**Summary Instructions:**\n- Use bullet points.\n- Write 2-3 sentences to summarise the underlying themes and topics.\n- Using ONLY the information provided, do not add any additional information that is not provided.\n- Be brief and concise.\n\nIf Special Instructions are provided by the user, they take precedence over any previous instructions. You MUST follow the instructions precisely.\n",
+        "variables": [],
+        "_type": "systemmessage"
+    },
+    {
+        "content": "\n###Central Text###\n{{central_text}}\n\n###Sample Texts###\n{{samples}}\n\n###Common Words###\n{{keywords}}\n\n###Special Instructions###\n{{instructions}}\n\n###Summary###\n",
+        "variables": [
+            "central_text",
+            "samples",
+            "keywords"
+        ],
+        "_type": "usermessage"
+    }
+]


### PR DESCRIPTION
### Added
- Added a new example on topic label customization (`examples/3_customize_topic_labels.jl`) and the corresponding sections in the FAQ.
- Added a few string cleanup tricks in `build_topic` function to strip unnecessary repetition of the prompt template in the generated labels.
- Added new templates `TopicLabelerWithInstructions` and `TopicSummarizerWithInstructions` that include the placeholder `instructions` to allow users to easily customize the labels and summaries, respectively.

### Fixed
- Fixed small typos in templates `TopicLabelerBasic` and `TopicSummarizerBasic`.

## Updated
- Updated logic in the `plot` to ensure topic labels are generated only when necessary. Use `build_clusters!` to force the generation of topic labels, or `plot` to generate them only if necessary.
- Increased compatibility for PromptingTools to 0.12.
